### PR TITLE
docs: add Examples/Documentation index

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,30 @@
+# Documentation Index
+
+- [](&)Documentation/3DInteractionsAPI.md
+- [](&)Documentation/3DInteractionsGuide.md
+- [](&)Documentation/AccessibilityAPI.md
+- [](&)Documentation/AccessibilityGuide.md
+- [](&)Documentation/API-Reference.md
+- [](&)Documentation/API.md
+- [](&)Documentation/Best-Practices.md
+- [](&)Documentation/ChangelogGuide.md
+- [](&)Documentation/ConfigurationAPI.md
+- [](&)Documentation/ConfigurationGuide.md
+- [](&)Documentation/ContributingGuide.md
+- [](&)Documentation/Getting-Started.md
+- [](&)Documentation/GettingStarted.md
+- [](&)Documentation/ImmersiveExperiencesAPI.md
+- [](&)Documentation/ImmersiveExperiencesGuide.md
+- [](&)Documentation/Installation.md
+- [](&)Documentation/LicenseGuide.md
+- [](&)Documentation/PerformanceAPI.md
+- [](&)Documentation/PerformanceGuide.md
+- [](&)Documentation/SpatialAudioAPI.md
+- [](&)Documentation/SpatialAudioGuide.md
+- [](&)Documentation/SpatialComputingBestPracticesGuide.md
+- [](&)Documentation/SpatialUIAPI.md
+- [](&)Documentation/SpatialUIGuide.md
+- [](&)Documentation/TestingGuide.md
+- [](&)Documentation/Troubleshooting.md
+- [](&)Documentation/TroubleshootingGuide.md
+- [](&)Documentation/VisionOSUIFrameworkManagerAPI.md

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,24 +1,11 @@
-# 💡 Examples
+# Examples Index
 
-Welcome to our comprehensive examples collection! Here you'll find practical implementations and usage patterns for our framework.
-
-## 📱 Available Examples
-
-### Basic Example
-- **File**: `BasicExample.swift`
-- **Description**: Simple implementation showing fundamental usage
-- **Difficulty**: Beginner
-- **Use Case**: Quick prototyping and learning
-
-## 🚀 Getting Started
-
-1. **Choose an example** that matches your skill level
-2. **Copy the code** into your project
-3. **Customize** according to your needs
-4. **Build and run** to see it in action
-
-## 📚 Related Documentation
-
-- [Getting Started](Documentation/GettingStarted.md)
-- [API Reference](Documentation/API.md)
-- [Installation Guide](Documentation/Installation.md)
+- ``Examples/3DInteractionExamples/3DInteractionExample.swift
+- ``Examples/AdvancedExample.swift
+- ``Examples/AdvancedExamples/GestureInteractionsExample.swift
+- ``Examples/AdvancedExamples/ImmersiveExperienceExample.swift
+- ``Examples/AdvancedExamples/SpatialWindowExample.swift
+- ``Examples/BasicExample.swift
+- ``Examples/ImmersiveExperienceExamples/ImmersiveExperienceExample.swift
+- ``Examples/SpatialAudioExamples/SpatialAudioExample.swift
+- ``Examples/SpatialUIExamples/SpatialUIExample.swift


### PR DESCRIPTION
Adds repo-specific indices for Examples and Documentation folders. English-only; no placeholders.